### PR TITLE
run commit and push re usable workflow

### DIFF
--- a/.github/workflows/run_hook_commit_and_push.yml
+++ b/.github/workflows/run_hook_commit_and_push.yml
@@ -1,0 +1,64 @@
+name: Run,Commit,Push
+
+on:
+  workflow_call:
+    inputs:
+      hook_to_run:
+        description: 'It will be the hook ro run. ex: npm run build'
+        type: string
+        required: true
+      token:
+        description: 'Personal Token or Installation token. This token should have commit permissions to append the changes to the PR, take a look at https://github.com/jnwng/github-app-installation-token-action for more information'
+        type: string
+        required: true
+      committer_email:
+        description: 'The email we want to commit with. We will use workflow at github.com by default'
+        type: string
+        required: false
+        default: 'workflow@github.com'
+      committer_name:
+        description: 'The Name we want to commit with. We will Github Workflow by default'
+        type: string
+        required: false
+        default: 'Github Workflow'
+      committer_message:
+        description: "The commit message we will like to append. We will use 'Changes found on Workflow' by default "
+        type: string
+        required: false
+        default: 'Changes found on Workflow'
+    outputs:
+      changed_found:
+        description: 'It will contain the changes found'
+        value: ${{ jobs.gitStatus.outputs.status }}
+
+jobs:
+  runCommitPush:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - name: execute hook
+        run: ${{ inputs.hook_to_run }}
+      - id: gitStatus
+        name: find files changed
+        run: |
+          STATUS=$(git diff --quiet && echo clean || echo modified)
+          echo "::set-output name=status::$STATUS"
+      - run: |
+          echo ${{ steps.gitStatus.outputs.status }}
+          echo ${{ contains(steps.gitStatus.outputs.status, 'modified') }}
+      - name: Commit changed Files
+        if: contains(steps.gitStatus.outputs.status, 'modified')
+        run: |
+          git config --local user.email "${{ inputs.committer_email }}"
+          git config --local user.name "${{ inputs.committer_name }}" 
+          git commit -m "${{ inputs.committer_message }}" -a
+      - name: Push Changes
+        if: contains(steps.gitStatus.outputs.status, 'modified')
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ inputs.token }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/run_hook_commit_and_push.yml
+++ b/.github/workflows/run_hook_commit_and_push.yml
@@ -7,10 +7,6 @@ on:
         description: 'It will be the hook ro run. ex: npm run build'
         type: string
         required: true
-      token:
-        description: 'Personal Token or Installation token. This token should have commit permissions to append the changes to the PR, take a look at https://github.com/jnwng/github-app-installation-token-action for more information'
-        type: string
-        required: true
       committer_email:
         description: 'The email we want to commit with. We will use workflow at github.com by default'
         type: string
@@ -28,6 +24,7 @@ on:
         default: 'Changes found on Workflow'
     secrets:
       token:
+        description: 'Personal Token or Installation token. This token should have commit permissions to append the changes to the PR, take a look at https://github.com/jnwng/github-app-installation-token-action for more information'
         required: true
     outputs:
       changed_found:

--- a/.github/workflows/run_hook_commit_and_push.yml
+++ b/.github/workflows/run_hook_commit_and_push.yml
@@ -7,6 +7,10 @@ on:
         description: 'It will be the hook ro run. ex: npm run build'
         type: string
         required: true
+      node_version:
+        type: string
+        description: 'node version we will execute `hook_to_run` with'
+        required: true
       committer_email:
         description: 'The email we want to commit with. We will use workflow at github.com by default'
         type: string
@@ -22,6 +26,7 @@ on:
         type: string
         required: false
         default: 'Changes found on Workflow'
+
     secrets:
       token:
         description: 'Personal Token or Installation token. This token should have commit permissions to append the changes to the PR, take a look at https://github.com/jnwng/github-app-installation-token-action for more information'

--- a/.github/workflows/run_hook_commit_and_push.yml
+++ b/.github/workflows/run_hook_commit_and_push.yml
@@ -46,6 +46,9 @@ jobs:
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
       - name: execute hook
+        uses: actions/setup-node@v2
+        with:
+          node-version: '${{ inputs.node_version }}'
         run: ${{ inputs.hook_to_run }}
       - id: gitStatus
         name: find files changed

--- a/.github/workflows/run_hook_commit_and_push.yml
+++ b/.github/workflows/run_hook_commit_and_push.yml
@@ -12,10 +12,10 @@ on:
         description: 'node version we will execute `hook_to_run` with'
         required: true
       committer_email:
-        description: 'The email we want to commit with. We will use workflow at github.com by default'
+        description: 'The email we want to commit with. We will use action@github.com by default'
         type: string
         required: false
-        default: 'workflow@github.com'
+        default: 'action@github.com'
       committer_name:
         description: 'The Name we want to commit with. We will Github Workflow by default'
         type: string

--- a/.github/workflows/run_hook_commit_and_push.yml
+++ b/.github/workflows/run_hook_commit_and_push.yml
@@ -68,5 +68,5 @@ jobs:
         if: contains(steps.gitStatus.outputs.status, 'modified')
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ inputs.token }}
+          github_token: ${{ secrets.token }}
           branch: ${{ github.ref }}

--- a/.github/workflows/run_hook_commit_and_push.yml
+++ b/.github/workflows/run_hook_commit_and_push.yml
@@ -26,6 +26,9 @@ on:
         type: string
         required: false
         default: 'Changes found on Workflow'
+    secrets:
+      token:
+        required: true
     outputs:
       changed_found:
         description: 'It will contain the changes found'

--- a/.github/workflows/run_hook_commit_and_push.yml
+++ b/.github/workflows/run_hook_commit_and_push.yml
@@ -45,10 +45,10 @@ jobs:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
-      - name: execute hook
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '${{ inputs.node_version }}'
+      - name: execute hook
         run: ${{ inputs.hook_to_run }}
       - id: gitStatus
         name: find files changed


### PR DESCRIPTION
I have many actions that would benefit from having a reusable workflow that can run a hook, check if the hook produces changes and if it does, commit whatever was found. 

particularly when dependebot or renovate create automatic Prs. 
